### PR TITLE
Clean render buffers before writing

### DIFF
--- a/core/src/buffered_renderer.rs
+++ b/core/src/buffered_renderer.rs
@@ -204,6 +204,8 @@ impl BufferedRenderer {
 
     /// Reads samples from the remainder and the output queue into the destination array.
     pub fn read(&mut self, dest: &mut [f32]) {
+        dest.fill(0.0);
+
         let mut i: usize = 0;
         let len = dest.len().min(self.remainder.len());
         let samples = self

--- a/core/src/channel_group/mod.rs
+++ b/core/src/channel_group/mod.rs
@@ -144,6 +144,7 @@ impl ChannelGroup {
         let channels = &mut self.channels;
         let sample_cache_vecs = &mut self.sample_cache_vecs;
 
+        buffer.fill(0.0);
         thread_pool.install(move || {
             channels
                 .par_iter_mut()


### PR DESCRIPTION
Was a thing in VoiceChannel but not in ChannelGroup or BufferedRenderer and it created confusion.

I think this is the last thing I wanted to do before release. If I remember anything else I'll put it in this PR.