### PR TITLE
Change channel/synth configuration methods

### DIFF
--- a/core/benches/send_events.rs
+++ b/core/benches/send_events.rs
@@ -58,7 +58,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         f.iter(|| {
             let init = ChannelInitOptions {
                 fade_out_killing: false,
-                ..Default::default()
             };
             let mut channel = VoiceChannel::new(init, stream_params, None);
             channel.process_event(ChannelEvent::Config(ChannelConfigEvent::SetSoundfonts(
@@ -76,7 +75,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         f.iter(|| {
             let init = ChannelInitOptions {
                 fade_out_killing: true,
-                ..Default::default()
             };
             let mut channel = VoiceChannel::new(init, stream_params, None);
             channel.process_event(ChannelEvent::Config(ChannelConfigEvent::SetSoundfonts(
@@ -94,7 +92,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         f.iter(|| {
             let init = ChannelInitOptions {
                 fade_out_killing: false,
-                ..Default::default()
             };
             let mut channel = VoiceChannel::new(init, stream_params, None);
             channel.process_event(ChannelEvent::Config(ChannelConfigEvent::SetSoundfonts(
@@ -112,7 +109,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         f.iter(|| {
             let init = ChannelInitOptions {
                 fade_out_killing: true,
-                ..Default::default()
             };
             let mut channel = VoiceChannel::new(init, stream_params, None);
             channel.process_event(ChannelEvent::Config(ChannelConfigEvent::SetSoundfonts(

--- a/core/src/channel/channel_sf.rs
+++ b/core/src/channel/channel_sf.rs
@@ -8,11 +8,16 @@ use crate::{
 
 use super::voice_spawner::VoiceSpawnerMatrix;
 
+#[derive(Default, PartialEq, Eq, Clone, Copy, Debug)]
+pub struct ProgramDescriptor {
+    pub bank: u8,
+    pub preset: u8,
+}
+
 pub struct ChannelSoundfont {
     soundfonts: Vec<Arc<dyn SoundfontBase>>,
     matrix: VoiceSpawnerMatrix,
-    curr_bank: u8,
-    curr_preset: u8,
+    curr_program: ProgramDescriptor,
 }
 
 impl Deref for ChannelSoundfont {
@@ -29,8 +34,7 @@ impl ChannelSoundfont {
         ChannelSoundfont {
             soundfonts: Vec::new(),
             matrix: VoiceSpawnerMatrix::new(),
-            curr_bank: 0,
-            curr_preset: 0,
+            curr_program: Default::default(),
         }
     }
 
@@ -41,10 +45,9 @@ impl ChannelSoundfont {
         }
     }
 
-    pub fn change_program(&mut self, bank: u8, preset: u8) {
-        if self.curr_bank != bank || self.curr_preset != preset {
-            self.curr_bank = bank;
-            self.curr_preset = preset;
+    pub fn change_program(&mut self, program: ProgramDescriptor) {
+        if self.curr_program != program {
+            self.curr_program = program;
             self.rebuild_matrix();
         }
     }
@@ -55,8 +58,8 @@ impl ChannelSoundfont {
         // if a preset/instr. has regions in any bank other than 0, all missing banks will be muted.
         // For drum patches the same applies with bank and preset switched.
 
-        let bank = self.curr_bank;
-        let preset = self.curr_preset;
+        let bank = self.curr_program.bank;
+        let preset = self.curr_program.preset;
 
         for k in 0..128u8 {
             for v in 0..128u8 {

--- a/core/src/channel/event.rs
+++ b/core/src/channel/event.rs
@@ -28,6 +28,10 @@ pub enum ChannelConfigEvent {
 
     /// Sets the layer count for the soundfont
     SetLayerCount(Option<usize>),
+
+    /// Controls whether the channel will be standard or percussion.
+    /// Setting to `true` will make the channel only use percussion patches.
+    SetPercussionMode(bool),
 }
 
 /// MIDI events for a channel.

--- a/core/src/channel_group/config.rs
+++ b/core/src/channel_group/config.rs
@@ -69,16 +69,10 @@ pub struct ChannelGroupConfig {
     /// See the `ChannelInitOptions` documentation for more information.
     pub channel_init_options: ChannelInitOptions,
 
-    /// Amount of VoiceChannel objects to be created
-    /// (Number of MIDI channels)
-    /// The MIDI 1 spec uses 16 channels.
+    /// Amount of VoiceChannel objects to be created (Number of MIDI channels).
+    /// The MIDI 1 spec uses 16 channels. If the channel count is 16 or
+    /// greater, then MIDI channel 10 will be set as the percussion channel.
     pub channel_count: u32,
-
-    /// A vector which specifies which of the created channels (indexes) will be used for drums.
-    ///
-    /// For example in a conventional 16 MIDI channel setup where channel 10 is used for
-    /// drums, the vector would be set as vec!\[9\] (counting from 0).
-    pub drums_channels: Vec<u32>,
 
     /// Parameters of the output audio.
     /// See the `AudioStreamParams` documentation for more information.

--- a/core/src/channel_group/config.rs
+++ b/core/src/channel_group/config.rs
@@ -1,5 +1,17 @@
 use crate::{channel::ChannelInitOptions, AudioStreamParams};
 
+/// Controls the channel format that will be used in the synthesizer.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum SynthFormat {
+    /// Standard MIDI format with 16 channels. Channel 10 will be used for percussion.
+    #[default]
+    MidiSingle,
+
+    /// Creates a custom number of channels with the default settings.
+    Custom { channels: u32 },
+}
+
 /// Defines the multithreading options for each task that supports it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -69,10 +81,9 @@ pub struct ChannelGroupConfig {
     /// See the `ChannelInitOptions` documentation for more information.
     pub channel_init_options: ChannelInitOptions,
 
-    /// Amount of VoiceChannel objects to be created (Number of MIDI channels).
-    /// The MIDI 1 spec uses 16 channels. If the channel count is 16 or
-    /// greater, then MIDI channel 10 will be set as the percussion channel.
-    pub channel_count: u32,
+    /// Defines the format that the synthesizer will use. See the `SynthFormat`
+    /// documentation for more information.
+    pub format: SynthFormat,
 
     /// Parameters of the output audio.
     /// See the `AudioStreamParams` documentation for more information.

--- a/core/src/channel_group/events.rs
+++ b/core/src/channel_group/events.rs
@@ -1,18 +1,14 @@
-use crate::channel::{ChannelAudioEvent, ChannelConfigEvent};
+use crate::channel::ChannelEvent;
 
 /// Wrapper enum for various events to be sent to a MIDI synthesizer.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SynthEvent {
-    /// An audio event to be sent to the specified channel.
-    /// See `ChannelAudioEvent` documentation for more information.
-    Channel(u32, ChannelAudioEvent),
+    /// A channel event to be sent to the specified channel.
+    /// See `ChannelEvent` documentation for more information.
+    Channel(u32, ChannelEvent),
 
-    /// An audio event to be sent to all available channels.
+    /// A channel event to be sent to all available channels.
     /// See `ChannelAudioEvent` documentation for more information.
-    AllChannels(ChannelAudioEvent),
-
-    /// Configuration event for all channels.
-    /// See `ChannelConfigEvent` documentation for more information.
-    ChannelConfig(ChannelConfigEvent),
+    AllChannels(ChannelEvent),
 }

--- a/core/src/channel_group/mod.rs
+++ b/core/src/channel_group/mod.rs
@@ -59,7 +59,12 @@ impl ChannelGroup {
             ),
         };
 
-        for _ in 0..config.channel_count {
+        let channel_count = match config.format {
+            SynthFormat::MidiSingle => 16,
+            SynthFormat::Custom { channels } => channels,
+        };
+
+        for _ in 0..channel_count {
             channels.push(VoiceChannel::new(
                 config.channel_init_options,
                 config.audio_params,
@@ -69,10 +74,10 @@ impl ChannelGroup {
             sample_cache_vecs.push(Vec::new());
         }
 
-        if config.channel_count >= 16 {
+        if config.format == SynthFormat::MidiSingle {
             channels[9].push_events_iter(std::iter::once(ChannelEvent::Config(
                 ChannelConfigEvent::SetPercussionMode(true),
-            )))
+            )));
         }
 
         Self {

--- a/core/src/channel_group/mod.rs
+++ b/core/src/channel_group/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    channel::{ChannelAudioEvent, ChannelEvent, VoiceChannel},
+    channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent, VoiceChannel},
     helpers::{prepapre_cache_vec, sum_simd},
     AudioPipe, AudioStreamParams,
 };
@@ -59,17 +59,20 @@ impl ChannelGroup {
             ),
         };
 
-        for i in 0..config.channel_count {
-            let mut init = config.channel_init_options;
-            init.drums_only = config.drums_channels.clone().into_iter().any(|c| c == i);
-
+        for _ in 0..config.channel_count {
             channels.push(VoiceChannel::new(
-                init,
+                config.channel_init_options,
                 config.audio_params,
                 channel_pool.clone(),
             ));
             channel_events_cache.push(Vec::new());
             sample_cache_vecs.push(Vec::new());
+        }
+
+        if config.channel_count >= 16 {
+            channels[9].push_events_iter(std::iter::once(ChannelEvent::Config(
+                ChannelConfigEvent::SetPercussionMode(true),
+            )))
         }
 
         Self {
@@ -86,27 +89,32 @@ impl ChannelGroup {
     /// See the `SynthEvent` documentation for more information.
     pub fn send_event(&mut self, event: SynthEvent) {
         match event {
-            SynthEvent::Channel(channel, event) => {
-                self.channel_events_cache[channel as usize].push(event);
-                self.cached_event_count += 1;
-                if self.cached_event_count > MAX_EVENT_CACHE_SIZE {
-                    self.flush_events();
+            SynthEvent::Channel(channel, event) => match event {
+                ChannelEvent::Audio(e) => {
+                    self.channel_events_cache[channel as usize].push(e);
+                    self.cached_event_count += 1;
+                    if self.cached_event_count > MAX_EVENT_CACHE_SIZE {
+                        self.flush_events();
+                    }
                 }
-            }
-            SynthEvent::AllChannels(event) => {
-                for channel in self.channel_events_cache.iter_mut() {
-                    channel.push(event);
+                ChannelEvent::Config(_) => self.channels[channel as usize].process_event(event),
+            },
+            SynthEvent::AllChannels(event) => match event {
+                ChannelEvent::Audio(e) => {
+                    for channel in self.channel_events_cache.iter_mut() {
+                        channel.push(e);
+                    }
+                    self.cached_event_count += self.channel_events_cache.len() as u32;
+                    if self.cached_event_count > MAX_EVENT_CACHE_SIZE {
+                        self.flush_events();
+                    }
                 }
-                self.cached_event_count += self.channel_events_cache.len() as u32;
-                if self.cached_event_count > MAX_EVENT_CACHE_SIZE {
-                    self.flush_events();
+                ChannelEvent::Config(_) => {
+                    for channel in self.channels.iter_mut() {
+                        channel.process_event(event.clone());
+                    }
                 }
-            }
-            SynthEvent::ChannelConfig(config) => {
-                for channel in self.channels.iter_mut() {
-                    channel.process_event(ChannelEvent::Config(config.clone()));
-                }
-            }
+            },
         }
     }
 

--- a/realtime/examples/bench.rs
+++ b/realtime/examples/bench.rs
@@ -1,5 +1,5 @@
 use std::time::{Duration, Instant};
-use xsynth_core::channel::ChannelAudioEvent;
+use xsynth_core::channel::{ChannelAudioEvent, ChannelEvent};
 
 use xsynth_realtime::{RealtimeSynth, SynthEvent};
 
@@ -12,13 +12,13 @@ fn main() {
             for _ in 0..100 {
                 synth.send_event(SynthEvent::Channel(
                     0,
-                    ChannelAudioEvent::NoteOn { key: 0, vel: 5 },
+                    ChannelEvent::Audio(ChannelAudioEvent::NoteOn { key: 0, vel: 5 }),
                 ));
             }
             for _ in 0..100 {
                 synth.send_event(SynthEvent::Channel(
                     0,
-                    ChannelAudioEvent::NoteOff { key: 0 },
+                    ChannelEvent::Audio(ChannelAudioEvent::NoteOff { key: 0 }),
                 ));
             }
         }

--- a/realtime/examples/midi2.rs
+++ b/realtime/examples/midi2.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use xsynth_core::{
-    channel::{ChannelAudioEvent, ChannelConfigEvent, ControlEvent},
+    channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent, ControlEvent},
     soundfont::{SampleSoundfont, SoundfontBase},
 };
 
@@ -48,7 +48,9 @@ fn main() {
         SampleSoundfont::new(sfz, params, Default::default()).unwrap(),
     )];
 
-    sender.send_config(ChannelConfigEvent::SetSoundfonts(soundfonts));
+    sender.send_event(SynthEvent::AllChannels(ChannelEvent::Config(
+        ChannelConfigEvent::SetSoundfonts(soundfonts),
+    )));
 
     let midi = MIDIFile::open(&midi, None).unwrap();
 
@@ -89,36 +91,39 @@ fn main() {
             Event::NoteOn(e) => {
                 sender.send_event(SynthEvent::Channel(
                     e.channel as u32,
-                    ChannelAudioEvent::NoteOn {
+                    ChannelEvent::Audio(ChannelAudioEvent::NoteOn {
                         key: e.key,
                         vel: e.velocity,
-                    },
+                    }),
                 ));
             }
             Event::NoteOff(e) => {
                 sender.send_event(SynthEvent::Channel(
                     e.channel as u32,
-                    ChannelAudioEvent::NoteOff { key: e.key },
+                    ChannelEvent::Audio(ChannelAudioEvent::NoteOff { key: e.key }),
                 ));
             }
             Event::ControlChange(e) => {
                 sender.send_event(SynthEvent::Channel(
                     e.channel as u32,
-                    ChannelAudioEvent::Control(ControlEvent::Raw(e.controller, e.value)),
+                    ChannelEvent::Audio(ChannelAudioEvent::Control(ControlEvent::Raw(
+                        e.controller,
+                        e.value,
+                    ))),
                 ));
             }
             Event::PitchWheelChange(e) => {
                 sender.send_event(SynthEvent::Channel(
                     e.channel as u32,
-                    ChannelAudioEvent::Control(ControlEvent::PitchBendValue(
+                    ChannelEvent::Audio(ChannelAudioEvent::Control(ControlEvent::PitchBendValue(
                         e.pitch as f32 / 8192.0,
-                    )),
+                    ))),
                 ));
             }
             Event::ProgramChange(e) => {
                 sender.send_event(SynthEvent::Channel(
                     e.channel as u32,
-                    ChannelAudioEvent::ProgramChange(e.program),
+                    ChannelEvent::Audio(ChannelAudioEvent::ProgramChange(e.program)),
                 ));
             }
             _ => {}

--- a/realtime/examples/test.rs
+++ b/realtime/examples/test.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 use xsynth_core::{
-    channel::{ChannelAudioEvent, ChannelConfigEvent},
+    channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent},
     soundfont::{SampleSoundfont, SoundfontBase},
 };
 
@@ -31,7 +31,9 @@ fn main() {
         SampleSoundfont::new(sfz, params, Default::default()).unwrap(),
     )];
 
-    sender.send_config(ChannelConfigEvent::SetSoundfonts(soundfonts));
+    sender.send_event(SynthEvent::AllChannels(ChannelEvent::Config(
+        ChannelConfigEvent::SetSoundfonts(soundfonts),
+    )));
 
     // for k in 0..127 {
     //     for c in 0..16 {
@@ -45,7 +47,7 @@ fn main() {
     // }
     sender.send_event(SynthEvent::Channel(
         0,
-        ChannelAudioEvent::NoteOn { key: 10, vel: 127 },
+        ChannelEvent::Audio(ChannelAudioEvent::NoteOn { key: 10, vel: 127 }),
     ));
 
     std::thread::sleep(Duration::from_secs(10000));

--- a/realtime/examples/unload.rs
+++ b/realtime/examples/unload.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use xsynth_core::{
-    channel::{ChannelAudioEvent, ChannelConfigEvent},
+    channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent},
     soundfont::{SampleSoundfont, SoundfontBase},
 };
 
@@ -34,11 +34,13 @@ fn main() {
     )];
     println!("Loaded");
 
-    sender.send_config(ChannelConfigEvent::SetSoundfonts(soundfonts));
+    sender.send_event(SynthEvent::AllChannels(ChannelEvent::Config(
+        ChannelConfigEvent::SetSoundfonts(soundfonts),
+    )));
 
     sender.send_event(SynthEvent::Channel(
         0,
-        ChannelAudioEvent::NoteOn { key: 64, vel: 127 },
+        ChannelEvent::Audio(ChannelAudioEvent::NoteOn { key: 64, vel: 127 }),
     ));
 
     std::thread::sleep(Duration::from_secs(1));

--- a/realtime/src/config.rs
+++ b/realtime/src/config.rs
@@ -14,18 +14,12 @@ pub struct XSynthRealtimeConfig {
     /// Default: `10.0`
     pub render_window_ms: f64,
 
-    /// Amount of VoiceChannel objects to be created.
-    /// (Number of MIDI channels)
+    /// Amount of VoiceChannel objects to be created (Number of MIDI channels).
+    /// The MIDI 1 spec uses 16 channels. If the channel count is 16 or
+    /// greater, then MIDI channel 10 will be set as the percussion channel.
     ///
     /// Default: `16`
     pub channel_count: u32,
-
-    /// A vector which specifies which of the created channels (indexes) will be used for drums.
-    /// For example in a conventional 16 MIDI channel setup where channel 10 is used for
-    /// drums, the vector would be set as \[9\] (counting from 0).
-    ///
-    /// Default: `[9]`
-    pub drums_channels: Vec<u32>,
 
     /// Controls the multithreading used for rendering per-voice audio for all
     /// the voices stored in a key for a channel. See the `ThreadCount` documentation
@@ -46,7 +40,6 @@ impl Default for XSynthRealtimeConfig {
             channel_init_options: Default::default(),
             render_window_ms: 10.0,
             channel_count: 16,
-            drums_channels: vec![9],
             multithreading: ThreadCount::None,
             ignore_range: 0..=0,
         }

--- a/render/examples/render.rs
+++ b/render/examples/render.rs
@@ -70,7 +70,6 @@ fn main() {
         group_options: ChannelGroupConfig {
             channel_init_options: Default::default(),
             channel_count: 16,
-            drums_channels: vec![9],
             audio_params: AudioStreamParams::new(48000, 2.into()),
             parallelism: Default::default(),
         },

--- a/render/examples/render.rs
+++ b/render/examples/render.rs
@@ -69,7 +69,7 @@ fn main() {
     let config = XSynthRenderConfig {
         group_options: ChannelGroupConfig {
             channel_init_options: Default::default(),
-            channel_count: 16,
+            format: Default::default(),
             audio_params: AudioStreamParams::new(48000, 2.into()),
             parallelism: Default::default(),
         },

--- a/render/examples/render_dialog.rs
+++ b/render/examples/render_dialog.rs
@@ -84,7 +84,6 @@ fn main() {
         group_options: ChannelGroupConfig {
             channel_init_options: Default::default(),
             channel_count: 16,
-            drums_channels: vec![9],
             audio_params: AudioStreamParams::new(sample_rate, 2.into()),
             parallelism: if use_threadpool {
                 Default::default()

--- a/render/examples/render_dialog.rs
+++ b/render/examples/render_dialog.rs
@@ -83,7 +83,7 @@ fn main() {
     let config = XSynthRenderConfig {
         group_options: ChannelGroupConfig {
             channel_init_options: Default::default(),
-            channel_count: 16,
+            format: Default::default(),
             audio_params: AudioStreamParams::new(sample_rate, 2.into()),
             parallelism: if use_threadpool {
                 Default::default()

--- a/render/src/builder.rs
+++ b/render/src/builder.rs
@@ -6,7 +6,7 @@ use crate::{
 use std::sync::Arc;
 
 use xsynth_core::{
-    channel::{ChannelAudioEvent, ChannelConfigEvent, ControlEvent},
+    channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent, ControlEvent},
     channel_group::SynthEvent,
     soundfont::{LoadSfError, SoundfontBase},
 };
@@ -146,17 +146,17 @@ impl<'a, ProgressCallback: FnMut(XSynthRenderStats)> XSynthRenderBuilder<'a, Pro
     pub fn run(mut self) -> Result<(), XSynthRenderError> {
         let mut synth = XSynthRender::new(self.config.clone(), self.out_path.into());
 
-        synth.send_event(SynthEvent::ChannelConfig(
+        synth.send_event(SynthEvent::AllChannels(ChannelEvent::Config(
             ChannelConfigEvent::SetSoundfonts(
                 self.soundfonts
                     .drain(..)
                     .collect::<Vec<Arc<dyn SoundfontBase>>>(),
             ),
-        ));
+        )));
 
-        synth.send_event(SynthEvent::ChannelConfig(
+        synth.send_event(SynthEvent::AllChannels(ChannelEvent::Config(
             ChannelConfigEvent::SetLayerCount(self.layer_count),
-        ));
+        )));
 
         let midi = MIDIFile::open(self.midi_path, None)?;
 
@@ -185,44 +185,51 @@ impl<'a, ProgressCallback: FnMut(XSynthRenderStats)> XSynthRenderBuilder<'a, Pro
                     Event::NoteOn(e) => {
                         synth.send_event(SynthEvent::Channel(
                             e.channel as u32,
-                            ChannelAudioEvent::NoteOn {
+                            ChannelEvent::Audio(ChannelAudioEvent::NoteOn {
                                 key: e.key,
                                 vel: e.velocity,
-                            },
+                            }),
                         ));
                     }
                     Event::NoteOff(e) => {
                         synth.send_event(SynthEvent::Channel(
                             e.channel as u32,
-                            ChannelAudioEvent::NoteOff { key: e.key },
+                            ChannelEvent::Audio(ChannelAudioEvent::NoteOff { key: e.key }),
                         ));
                     }
                     Event::ControlChange(e) => {
                         synth.send_event(SynthEvent::Channel(
                             e.channel as u32,
-                            ChannelAudioEvent::Control(ControlEvent::Raw(e.controller, e.value)),
+                            ChannelEvent::Audio(ChannelAudioEvent::Control(ControlEvent::Raw(
+                                e.controller,
+                                e.value,
+                            ))),
                         ));
                     }
                     Event::PitchWheelChange(e) => {
                         synth.send_event(SynthEvent::Channel(
                             e.channel as u32,
-                            ChannelAudioEvent::Control(ControlEvent::PitchBendValue(
-                                e.pitch as f32 / 8192.0,
+                            ChannelEvent::Audio(ChannelAudioEvent::Control(
+                                ControlEvent::PitchBendValue(e.pitch as f32 / 8192.0),
                             )),
                         ));
                     }
                     Event::ProgramChange(e) => {
                         synth.send_event(SynthEvent::Channel(
                             e.channel as u32,
-                            ChannelAudioEvent::ProgramChange(e.program),
+                            ChannelEvent::Audio(ChannelAudioEvent::ProgramChange(e.program)),
                         ));
                     }
                     _ => {}
                 }
             }
         }
-        synth.send_event(SynthEvent::AllChannels(ChannelAudioEvent::AllNotesOff));
-        synth.send_event(SynthEvent::AllChannels(ChannelAudioEvent::ResetControl));
+        synth.send_event(SynthEvent::AllChannels(ChannelEvent::Audio(
+            ChannelAudioEvent::AllNotesOff,
+        )));
+        synth.send_event(SynthEvent::AllChannels(ChannelEvent::Audio(
+            ChannelAudioEvent::ResetControl,
+        )));
         synth.finalize();
 
         Ok(())

--- a/render/src/builder.rs
+++ b/render/src/builder.rs
@@ -23,7 +23,7 @@ use midi_toolkit::{
     },
 };
 
-pub use xsynth_core::channel_group::ParallelismOptions;
+pub use xsynth_core::channel_group::{ParallelismOptions, SynthFormat};
 
 /// Statistics of an XSynthRender object.
 pub struct XSynthRenderStats {
@@ -86,8 +86,8 @@ impl<'a, ProgressCallback: FnMut(XSynthRenderStats)> XSynthRenderBuilder<'a, Pro
         self
     }
 
-    pub fn with_channel_count(mut self, channels: u32) -> Self {
-        self.config.group_options.channel_count = channels;
+    pub fn with_synth_format(mut self, format: SynthFormat) -> Self {
+        self.config.group_options.format = format;
         self
     }
 


### PR DESCRIPTION
- Made the percussion/drum option be a `ChannelConfigEvent`
- Made `SynthEvent` to use `ChannelEvent` instead of audio of config so it is a bit more verbose and configurable

I haven't benchmarked this yet