### PR TITLE
Force cpal Stream to implement Send+Sync

### DIFF
--- a/realtime/src/realtime_synth.rs
+++ b/realtime/src/realtime_synth.rs
@@ -70,10 +70,14 @@ impl RealtimeSynthStatsReader {
     }
 }
 
+struct SendSyncStream(Stream);
+unsafe impl Sync for SendSyncStream {}
+unsafe impl Send for SendSyncStream {}
+
 struct RealtimeSynthThreadSharedData {
     buffered_renderer: Arc<Mutex<BufferedRenderer>>,
 
-    stream: Stream,
+    stream: SendSyncStream,
 
     event_senders: RealtimeEventSender,
 }
@@ -272,7 +276,7 @@ impl RealtimeSynth {
                 buffered_renderer: buffered,
 
                 event_senders: RealtimeEventSender::new(senders, max_nps, config.ignore_range),
-                stream,
+                stream: SendSyncStream(stream),
             }),
             join_handles: thread_handles,
 
@@ -329,13 +333,13 @@ impl RealtimeSynth {
     /// Pauses the playback of the audio output device.
     pub fn pause(&mut self) -> Result<(), PauseStreamError> {
         let data = self.data.as_mut().unwrap();
-        data.stream.pause()
+        data.stream.0.pause()
     }
 
     /// Resumes the playback of the audio output device.
     pub fn resume(&mut self) -> Result<(), PlayStreamError> {
         let data = self.data.as_mut().unwrap();
-        data.stream.play()
+        data.stream.0.play()
     }
 
     /// Changes the length of the buffer reader.

--- a/realtime/src/realtime_synth.rs
+++ b/realtime/src/realtime_synth.rs
@@ -70,7 +70,7 @@ impl RealtimeSynthStatsReader {
     }
 }
 
-// A helper for making the stream be send/sync, allowing the entire synth to be passed between threads. 
+// A helper for making the stream be send/sync, allowing the entire synth to be passed between threads.
 // The stream is never actually accessed from multiple threads, it's only stored for ownership and then dropped.
 struct SendSyncStream(Stream);
 unsafe impl Sync for SendSyncStream {}

--- a/realtime/src/realtime_synth.rs
+++ b/realtime/src/realtime_synth.rs
@@ -70,6 +70,8 @@ impl RealtimeSynthStatsReader {
     }
 }
 
+// A helper for making the stream be send/sync, allowing the entire synth to be passed between threads. 
+// The stream is never actually accessed from multiple threads, it's only stored for ownership and then dropped.
 struct SendSyncStream(Stream);
 unsafe impl Sync for SendSyncStream {}
 unsafe impl Send for SendSyncStream {}


### PR DESCRIPTION
*Should* be fine since we realistically only keep `Stream` for dropping...
One thing we could change to make this more "safe" is removing the `play()` and `pause()` functions from the `RealtimeSynth` struct.

See [here](https://github.com/RustAudio/cpal/issues/818) and [here](https://github.com/RustAudio/cpal/pull/840).